### PR TITLE
Cipher/vigenere encryption

### DIFF
--- a/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher.vcxproj
+++ b/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher.vcxproj
@@ -36,7 +36,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v143</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
+    <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>

--- a/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
+++ b/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
@@ -1,13 +1,31 @@
 include Irvine32.inc
 
 .data
-msg BYTE "Hello World!", 0
+	promptPlainText	 BYTE "Enter plaintext: ", 0
+	promptKeyword	 BYTE "Enter keyword: ", 0
+
+	maxLength		 = 100
+	plainText		 BYTE maxLength DUP(?)
+	keyword			 BYTE maxLength DUP(?)
 
 .code
 main PROC
-    mov edx, OFFSET msg
-    call WriteString
-    call Crlf
-    exit
+	; Reading PlainText
+	mov edx, OFFSET promptPlainText
+	call WriteString
+
+	mov edx, OFFSET plainText
+	mov ecx, maxLength
+	call ReadString
+
+	; Reading Keyword
+	mov edx, OFFSET promptKeyword
+	call WriteString
+
+	mov edx, OFFSET keyword
+	mov ecx, maxLength
+	call ReadString
+
+	exit
 main ENDP
 END main

--- a/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
+++ b/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
@@ -8,6 +8,9 @@ include Irvine32.inc
 	plainText		 BYTE maxLength DUP(?)
 	keyword			 BYTE maxLength DUP(?)
 
+	debugPlainTextMsg   BYTE "[DEBUG] Uppercase Plaintext: ", 0
+    debugKeywordMsg     BYTE "[DEBUG] Uppercase Keyword: ", 0
+
 .code
 main PROC
 	; Reading PlainText
@@ -25,6 +28,68 @@ main PROC
 	mov edx, OFFSET keyword
 	mov ecx, maxLength
 	call ReadString
+
+	; Converting PLAINTEXT to uppercase
+	mov esi, OFFSET plainText
+	convertPlainTextLoop:
+		; Checking if it's the end of the string
+		mov al, [esi]
+		cmp al, 0
+		je convertKeyword
+
+		; Checking if it's in lowercase range i.e 0-25
+		cmp al, 'a'
+		jb skipConvert
+		cmp al, 'z'
+		ja skipConvert
+
+		; Converting to Uppercase
+		sub al, 32
+		mov [esi], al
+	
+	skipConvert:
+		inc esi
+		jmp convertPlainTextLoop
+
+	convertKeyword:
+		mov esi, OFFSET keyword
+
+	convertKeywordLoop:
+		 mov al, [esi]
+		cmp al, 0
+		je doneConvert
+
+		cmp al, 'a'
+		jb skipKeyConvert
+		cmp al, 'z'
+		ja skipKeyConvert
+
+		sub al, 32
+		mov [esi], al
+
+	skipKeyConvert:
+		inc esi
+		jmp convertKeywordLoop
+
+	doneConvert:
+
+	printDebug:
+    call Crlf
+    mov edx, OFFSET debugPlainTextMsg
+    call WriteString
+
+    mov edx, OFFSET plainText
+    call WriteString
+
+    call Crlf
+    mov edx, OFFSET debugKeywordMsg
+    call WriteString
+
+    mov edx, OFFSET keyword
+    call WriteString
+    call Crlf
+
+
 
 	exit
 main ENDP


### PR DESCRIPTION
This pull request introduces two significant changes: a modification to the project configuration to use a multi-byte character set and substantial updates to the main assembly file to enhance functionality. The assembly changes include adding prompts for user input, implementing input validation by converting text to uppercase, and introducing debug messages for better traceability.

### Project Configuration Changes:
* Updated the `CharacterSet` in `Vigenère-AutoKey-Cipher.vcxproj` from `Unicode` to `MultiByte` to align with the assembly code's handling of strings.

### Assembly Code Enhancements:
* **User Input Handling**: Added prompts (`promptPlainText` and `promptKeyword`) and implemented functionality to read plaintext and keyword inputs from the user. (`main.asm`)
* **Input Validation**: Introduced loops to convert both plaintext and keyword inputs to uppercase, ensuring consistent processing regardless of the case of user input. (`main.asm`)
* **Debugging Support**: Added debug messages (`debugPlainTextMsg` and `debugKeywordMsg`) to display the uppercase versions of the plaintext and keyword for verification purposes. (`main.asm`)