### PR TITLE
Cipher/vigenere encryption

### DIFF
--- a/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
+++ b/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
@@ -1,115 +1,166 @@
 include Irvine32.inc
 
 .data
-	promptPlainText	 BYTE "Enter plaintext: ", 0
-	promptKeyword	 BYTE "Enter keyword: ", 0
+    promptPlainText  BYTE "Enter plaintext: ", 0
+    promptKeyword    BYTE "Enter keyword: ", 0
+    resultMsg        BYTE "Encrypted text: ", 0
 
-	maxLength		 = 100
-	plainText		 BYTE maxLength DUP(?)
-	keyword			 BYTE maxLength DUP(?)
-	cipherText		 BYTE maxLength DUP(?)
+    maxLength        = 100
+    plainText        BYTE maxLength DUP(?)
+    keyword          BYTE maxLength DUP(?)
+    cipherText       BYTE maxLength DUP(?)
 
-	keyword_index	 DWORD 0     ; variable to hold index of current keyword letter
-	keyword_length	 DWORD ?     ; we will compute this
-
-	debugPlainTextMsg   BYTE "[DEBUG] Uppercase Plaintext: ", 0
+    keyword_length   DWORD ?     ; we will compute this
+    
+    debugPlainTextMsg   BYTE "[DEBUG] Uppercase Plaintext: ", 0
     debugKeywordMsg     BYTE "[DEBUG] Uppercase Keyword: ", 0
 
 .code
 main PROC
-	; Initial values
-	mov al, 0
-	mov [ciphertext], al     ; Put null terminator at start of ciphertext
-	mov keyword_index, 0
+    ; Reading PlainText
+    mov edx, OFFSET promptPlainText
+    call WriteString
 
-	; Reading PlainText
-	mov edx, OFFSET promptPlainText
-	call WriteString
+    mov edx, OFFSET plainText
+    mov ecx, maxLength
+    call ReadString
 
-	mov edx, OFFSET plainText
-	mov ecx, maxLength
-	call ReadString
+    ; Reading Keyword
+    mov edx, OFFSET promptKeyword
+    call WriteString
 
-	; Reading Keyword
-	mov edx, OFFSET promptKeyword
-	call WriteString
+    mov edx, OFFSET keyword
+    mov ecx, maxLength
+    call ReadString
 
-	mov edx, OFFSET keyword
-	mov ecx, maxLength
-	call ReadString
+    ; Get keyword length and save in memory
+    mov edx, OFFSET keyword
+    call Str_length
+    mov keyword_length, eax        ; store length in our variable
 
-	; Reading keyword length and saving in memory for use
-	mov edx, OFFSET keyword
-	call Str_length
-	mov keyword_length, eax        ; store length in our variable
+    ; Converting PLAINTEXT to uppercase
+    mov esi, OFFSET plainText
+    convertPlainTextLoop:
+        ; Check if it's the end of the string
+        mov al, [esi]
+        cmp al, 0
+        je convertKeyword
 
-	; Converting PLAINTEXT to uppercase
-	mov esi, OFFSET plainText
-	convertPlainTextLoop:
-		; Checking if it's the end of the string
-		mov al, [esi]
-		cmp al, 0
-		je convertKeyword
+        ; Check if it's in lowercase range
+        cmp al, 'a'
+        jb skipConvert
+        cmp al, 'z'
+        ja skipConvert
 
-		; Checking if it's in lowercase range i.e 0-25
-		cmp al, 'a'
-		jb skipConvert
-		cmp al, 'z'
-		ja skipConvert
+        ; Converting to Uppercase
+        sub al, 32
+        mov [esi], al
+    
+    skipConvert:
+        inc esi
+        jmp convertPlainTextLoop
 
-		; Converting to Uppercase
-		sub al, 32
-		mov [esi], al
-	
-	skipConvert:
-		inc esi
-		jmp convertPlainTextLoop
+    convertKeyword:
+        mov esi, OFFSET keyword
 
-	convertKeyword:
-		mov esi, OFFSET keyword
+    convertKeywordLoop:
+        mov al, [esi]
+        cmp al, 0
+        je doneConvert
 
-	convertKeywordLoop:
-		 mov al, [esi]
-		cmp al, 0
-		je doneConvert
+        cmp al, 'a'
+        jb skipKeyConvert
+        cmp al, 'z'
+        ja skipKeyConvert
 
-		cmp al, 'a'
-		jb skipKeyConvert
-		cmp al, 'z'
-		ja skipKeyConvert
+        sub al, 32
+        mov [esi], al
 
-		sub al, 32
-		mov [esi], al
+    skipKeyConvert:
+        inc esi
+        jmp convertKeywordLoop
 
-	skipKeyConvert:
-		inc esi
-		jmp convertKeywordLoop
+    doneConvert:
 
-	doneConvert:
-
-	; For DEBUG puposes, must remove this
-	printDebug:
+    ; For DEBUG purposes
     call Crlf
     mov edx, OFFSET debugPlainTextMsg
     call WriteString
-
     mov edx, OFFSET plainText
     call WriteString
 
     call Crlf
     mov edx, OFFSET debugKeywordMsg
     call WriteString
-
     mov edx, OFFSET keyword
     call WriteString
     call Crlf
 
-	; Initialize pointers
-    mov esi, OFFSET plaintext     ; ESI = current plaintext char
-    mov edi, OFFSET ciphertext    ; EDI = where to store next cipher char
-    mov ebx, 0                    ; EBX = keyword_index
-    mov ecx, keyword_length       ; ECX = keyword_length
+    ; Encryption process
+    mov esi, OFFSET plainText      ; Source pointer (plaintext)
+    mov edi, OFFSET cipherText     ; Destination pointer (ciphertext)
+    mov ecx, 0                     ; Keyword position counter
 
-	exit
+    encrypt_loop:
+        ; Get next plaintext character
+        mov al, [esi]
+        cmp al, 0                  ; Check for end of string
+        je done_encrypt
+
+        ; Check if char is a letter: 'A' to 'Z'
+        cmp al, 'A'
+        jb not_letter
+        cmp al, 'Z'
+        ja not_letter
+
+        ; Get the corresponding keyword character
+        push eax                   ; Save plaintext character
+        mov eax, ecx               ; Current keyword position
+        xor edx, edx               ; Clear EDX for division
+        div keyword_length         ; EDX now contains position % keyword_length
+        mov ebx, OFFSET keyword    ; Get keyword base address
+        add ebx, edx               ; Add the remainder (position in keyword)
+        mov bl, [ebx]              ; Get the keyword character
+        sub bl, 'A'                ; Convert to 0-25 value
+        pop eax                    ; Restore plaintext character
+
+        ; Encrypt the character
+        sub al, 'A'                ; Convert plaintext to 0-25
+        add al, bl                 ; Add keyword shift
+        
+        ; Take modulo 26 more carefully
+        movzx edx, al              ; Move with zero extend to avoid sign issues
+        mov ebx, 26
+        xor eax, eax               ; Clear EAX
+        mov al, dl                 ; Move character value back
+        xor edx, edx               ; Clear EDX for division
+        div bl                     ; Divide by 26, remainder in AH
+        mov al, ah                 ; Get remainder (modulo result)
+        
+        add al, 'A'                ; Convert back to ASCII
+        mov [edi], al              ; Store in ciphertext
+        inc ecx                    ; Move to next keyword position
+        jmp next_char
+
+    not_letter:
+        mov [edi], al              ; Copy non-letter characters unchanged
+        
+    next_char:
+        inc esi                    ; Move to next plaintext character
+        inc edi                    ; Move to next ciphertext position
+        jmp encrypt_loop
+
+    done_encrypt:
+        mov BYTE PTR [edi], 0      ; Null-terminate the ciphertext
+
+    ; Display the result
+    call Crlf
+    mov edx, OFFSET resultMsg
+    call WriteString
+    mov edx, OFFSET cipherText
+    call WriteString
+    call Crlf
+
+    exit
 main ENDP
 END main

--- a/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
+++ b/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
@@ -10,6 +10,7 @@ include Irvine32.inc
 	cipherText		 BYTE maxLength DUP(?)
 
 	keyword_index	 DWORD 0     ; variable to hold index of current keyword letter
+	keyword_length	 DWORD ?     ; we will compute this
 
 	debugPlainTextMsg   BYTE "[DEBUG] Uppercase Plaintext: ", 0
     debugKeywordMsg     BYTE "[DEBUG] Uppercase Keyword: ", 0
@@ -36,6 +37,11 @@ main PROC
 	mov edx, OFFSET keyword
 	mov ecx, maxLength
 	call ReadString
+
+	; Reading keyword length and saving in memory for use
+	mov edx, OFFSET keyword
+	call Str_length
+	mov keyword_length, eax        ; store length in our variable
 
 	; Converting PLAINTEXT to uppercase
 	mov esi, OFFSET plainText
@@ -98,7 +104,11 @@ main PROC
     call WriteString
     call Crlf
 
-
+	; Initialize pointers
+    mov esi, OFFSET plaintext     ; ESI = current plaintext char
+    mov edi, OFFSET ciphertext    ; EDI = where to store next cipher char
+    mov ebx, 0                    ; EBX = keyword_index
+    mov ecx, keyword_length       ; ECX = keyword_length
 
 	exit
 main ENDP

--- a/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
+++ b/Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asm
@@ -7,12 +7,20 @@ include Irvine32.inc
 	maxLength		 = 100
 	plainText		 BYTE maxLength DUP(?)
 	keyword			 BYTE maxLength DUP(?)
+	cipherText		 BYTE maxLength DUP(?)
+
+	keyword_index	 DWORD 0     ; variable to hold index of current keyword letter
 
 	debugPlainTextMsg   BYTE "[DEBUG] Uppercase Plaintext: ", 0
     debugKeywordMsg     BYTE "[DEBUG] Uppercase Keyword: ", 0
 
 .code
 main PROC
+	; Initial values
+	mov al, 0
+	mov [ciphertext], al     ; Put null terminator at start of ciphertext
+	mov keyword_index, 0
+
 	; Reading PlainText
 	mov edx, OFFSET promptPlainText
 	call WriteString
@@ -73,6 +81,7 @@ main PROC
 
 	doneConvert:
 
+	; For DEBUG puposes, must remove this
 	printDebug:
     call Crlf
     mov edx, OFFSET debugPlainTextMsg


### PR DESCRIPTION
This pull request introduces functionality to perform Vigenère AutoKey Cipher encryption in the `main.asm` file. The changes include adding new data structures, calculating the keyword length, implementing the encryption process, and displaying the encrypted result.

### Data structure additions:
* Added a `resultMsg` string to display the encryption result and a `cipherText` buffer to store the encrypted text. A `keyword_length` variable was also introduced to hold the computed length of the keyword. (`[Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asmR6-R13](diffhunk://#diff-97926cb801dca5973ade020ab06765a64498f8746a862cf6be6a59a3b3b5a374R6-R13)`)

### Keyword length computation:
* Added logic to compute the length of the keyword using the `Str_length` function and store it in the `keyword_length` variable. (`[Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asmR36-R49](diffhunk://#diff-97926cb801dca5973ade020ab06765a64498f8746a862cf6be6a59a3b3b5a374R36-R49)`)

### Encryption process:
* Implemented the Vigenère AutoKey Cipher encryption logic:
  - Loops through the plaintext, converts characters to uppercase, and processes only alphabetic characters.
  - Aligns plaintext with the keyword using modulo arithmetic for repeated keyword usage.
  - Encrypts each character by shifting it based on the corresponding keyword character.
  - Handles non-alphabetic characters by copying them unchanged.
  - Stores the encrypted result in the `cipherText` buffer and null-terminates it. (`[Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asmL76-R162](diffhunk://#diff-97926cb801dca5973ade020ab06765a64498f8746a862cf6be6a59a3b3b5a374L76-R162)`)

### Output enhancements:
* Added functionality to display the encrypted text by printing the `resultMsg` followed by the contents of the `cipherText` buffer. (`[Vigenère-AutoKey-Cipher/Vigenère-AutoKey-Cipher/main.asmL76-R162](diffhunk://#diff-97926cb801dca5973ade020ab06765a64498f8746a862cf6be6a59a3b3b5a374L76-R162)`)